### PR TITLE
CTP: example of usage for TH1FRatio

### DIFF
--- a/Modules/CTP/CMakeLists.txt
+++ b/Modules/CTP/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_link_libraries(O2QcCTP PUBLIC O2QualityControl O2::DataFormatsCTP O2::CTPReconstruction)
+target_link_libraries(O2QcCTP PUBLIC O2QualityControl O2QcCommon O2::DataFormatsCTP O2::CTPReconstruction)
 
 install(TARGETS O2QcCTP
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Modules/CTP/include/CTP/RawDataQcTask.h
+++ b/Modules/CTP/include/CTP/RawDataQcTask.h
@@ -20,10 +20,14 @@
 
 #include "QualityControl/TaskInterface.h"
 #include "CTPReconstruction/RawDataDecoder.h"
+#include "Common/TH1Ratio.h"
+
+#include <memory>
 
 class TH1F;
 
 using namespace o2::quality_control::core;
+using namespace o2::quality_control_modules::common;
 
 namespace o2::quality_control_modules::ctp
 {
@@ -48,7 +52,7 @@ class CTPRawDataReaderTask final : public TaskInterface
 
  private:
   o2::ctp::RawDataDecoder mDecoder;
-  TH1F* mHistoInputs = nullptr;
+  std::unique_ptr<TH1FRatio> mHistoInputs;
   TH1F* mHistoClasses = nullptr;
   TH1F* mHistoInputRatios = nullptr;
   TH1F* mHistoClassRatios = nullptr;

--- a/Modules/CTP/include/CTP/RawDataReaderCheck.h
+++ b/Modules/CTP/include/CTP/RawDataReaderCheck.h
@@ -48,7 +48,7 @@ class RawDataReaderCheck : public o2::quality_control::checker::CheckInterface
  private:
   int getRunNumberFromMO(std::shared_ptr<MonitorObject> mo);
   int getNumberFilledBins(TH1F* hist);
-  int checkChange(TH1F* fHistDiference, TH1F* fHistPrev, std::vector<int>& vIndexBad, std::vector<int>& vIndexMedium);
+  int checkChange(TH1F* fHist, TH1F* fHistPrev, std::vector<int>& vIndexBad, std::vector<int>& vIndexMedium);
   int mRunNumber;
   long int mTimestamp;
   float mThreshold;

--- a/Modules/CTP/src/RawDataQcTask.cxx
+++ b/Modules/CTP/src/RawDataQcTask.cxx
@@ -29,13 +29,14 @@
 #include <Framework/InputRecord.h>
 #include <Framework/InputRecordWalker.h>
 #include "Framework/TimingInfo.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 namespace o2::quality_control_modules::ctp
 {
 
 CTPRawDataReaderTask::~CTPRawDataReaderTask()
 {
-  delete mHistoInputs;
+  //delete mHistoInputs; <= not needed with smart pointers
   delete mHistoClasses;
   delete mHistoMTVXBC;
   delete mHistoInputRatios;
@@ -48,14 +49,14 @@ void CTPRawDataReaderTask::initialize(o2::framework::InitContext& /*ctx*/)
   int ninps = o2::ctp::CTP_NINPUTS + 1;
   int nclasses = o2::ctp::CTP_NCLASSES + 1;
   int norbits = o2::constants::lhc::LHCMaxBunches;
-  mHistoInputs = new TH1F("inputs", "Inputs distribution", ninps, 0, ninps);
-  mHistoInputs->SetCanExtend(TH1::kAllAxes);
+  mHistoInputs = std::make_unique<TH1FRatio>("inputs", "Inputs distribution;;rate (kHz)", ninps, 0, ninps, true);
+  mHistoInputs->getNum()->SetCanExtend(TH1::kAllAxes);
   mHistoClasses = new TH1F("classes", "Classes distribution", nclasses, 0, nclasses);
   mHistoMTVXBC = new TH1F("bcMTVX", "BC position of MTVX", norbits, 0, norbits);
   mHistoInputRatios = new TH1F("inputRatio", "Input Ratio distribution", ninps, 0, ninps);
   mHistoInputRatios->SetCanExtend(TH1::kAllAxes);
   mHistoClassRatios = new TH1F("classRatio", "Class Ratio distribution", nclasses, 0, nclasses);
-  getObjectsManager()->startPublishing(mHistoInputs);
+  getObjectsManager()->startPublishing(mHistoInputs.get());
   getObjectsManager()->startPublishing(mHistoClasses);
   getObjectsManager()->startPublishing(mHistoClassRatios);
   getObjectsManager()->startPublishing(mHistoInputRatios);
@@ -82,11 +83,15 @@ void CTPRawDataReaderTask::startOfCycle()
 
 void CTPRawDataReaderTask::monitorData(o2::framework::ProcessingContext& ctx)
 {
+  static constexpr double sOrbitLengthInMS = o2::constants::lhc::LHCOrbitMUS / 1000;
+
   // LOG(info) << "============  Starting monitoring ================== ";
   //   get the input
   std::vector<o2::framework::InputSpec> filter;
   std::vector<o2::ctp::LumiInfo> lumiPointsHBF1;
   std::vector<o2::ctp::CTPDigit> outputDigits;
+
+  auto nOrbitsPerTF = o2::base::GRPGeomHelper::instance().getNHBFPerTF();
 
   o2::framework::InputRecord& inputs = ctx.inputs();
   mDecoder.decodeRaw(inputs, filter, outputDigits, lumiPointsHBF1);
@@ -99,7 +104,8 @@ void CTPRawDataReaderTask::monitorData(o2::framework::ProcessingContext& ctx)
     if (digit.CTPInputMask.count()) {
       for (int i = 0; i < o2::ctp::CTP_NINPUTS; i++) {
         if (digit.CTPInputMask[i]) {
-          mHistoInputs->Fill(ctpinputs[i], 1);
+          // store counts in numerator
+          mHistoInputs->getNum()->Fill(ctpinputs[i], 1);
           mHistoInputRatios->Fill(ctpinputs[i], 1);
           if (i == indexTvx - 1)
             mHistoMTVXBC->Fill(bcid);
@@ -115,14 +121,21 @@ void CTPRawDataReaderTask::monitorData(o2::framework::ProcessingContext& ctx)
       }
     }
   }
-  mHistoInputs->Fill(o2::ctp::CTP_NINPUTS);
+  mHistoInputs->getNum()->Fill(o2::ctp::CTP_NINPUTS);
   mHistoClasses->Fill(o2::ctp::CTP_NCLASSES);
+
+  // store total duration (in milliseconds) in denominator
+  mHistoInputs->getDen()->Fill((double)0, sOrbitLengthInMS * nOrbitsPerTF);
+
   // std::cout << " N TFs:" << mNTF << std::endl;
 }
 
 void CTPRawDataReaderTask::endOfCycle()
 {
   ILOG(Debug, Devel) << "endOfCycle" << ENDM;
+
+  // update the ratio of histograms
+  mHistoInputs->update();
 }
 
 void CTPRawDataReaderTask::endOfActivity(const Activity& /*activity*/)


### PR DESCRIPTION
- filling and updating of histogram ratios
- use of smart pointers to simplify memory handling
- better retrieval of number of orbits in TF
- changed raw data checker code to make it compatible with TH1FRatio